### PR TITLE
Fix for change in precedence of ':' operator in JAGS 4.0.0

### DIFF
--- a/gemtc/inst/gemtc.randomeffects.txt
+++ b/gemtc/inst/gemtc.randomeffects.txt
@@ -8,7 +8,7 @@ for (i in 1:ns) {
 		md[i, k] <- d[t[i, 1], t[i, k]] + sw[i, k]
 		taud[i, k] <- tau.d * 2 * (k - 1) / k
 		w[i, k] <- delta[i, k] - (d[t[i, 1], t[i, k]])
-		sw[i, k] <- sum(w[i, 1:k-1]) / (k - 1)
+		sw[i, k] <- sum(w[i, 1:(k-1)]) / (k - 1)
 	}
 }
 


### PR DESCRIPTION
In JAGS 4.0.0, the sequence operator ':' has the same precedence as in R. This means that the code "for(i in 1:k-1)" will generate a sequence 0, 1, ..., k-1 rather than 1, 2, ...(k-1) as JAGS 3.4.0 currently does, leading to a compile error. Use brackets to enforce correct precedence.

JAGS 4.0.0 is currently in beta and due for full release on 1 October, along with an updated rjags package on CRAN.