### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/gemtc/man/atrialFibrillation.Rd
+++ b/gemtc/man/atrialFibrillation.Rd
@@ -10,7 +10,7 @@ Data are take from Table 1 of Cooper et al. (2009), with the following correctio
 Cooper et al. (2009),
 \emph{Adressing between-study heterogeneity and inconsistency in mixed treatment comparisons: Application to stroke prevention treatments in individuals with non-rheumatic atrial fibrillation},
 Statistics in Medicine 28:1861-1881.
-[\href{http://dx.doi.org/10.1002/sim.3594}{doi:10.1002/sim.3594}]
+[\href{https://doi.org/10.1002/sim.3594}{doi:10.1002/sim.3594}]
 }
 \examples{
 # Build a model similar to Model 4(b) from Cooper et al. (2009):

--- a/gemtc/man/blocker.Rd
+++ b/gemtc/man/blocker.Rd
@@ -8,10 +8,10 @@
 S. Dias, A.J. Sutton, A.E. Ades, and N.J. Welton (2013a),
 \emph{A Generalized Linear Modeling Framework for Pairwise and Network Meta-analysis of Randomized Controlled Trials},
 Medical Decision Making 33(5):607-617.
-[\href{http://dx.doi.org/10.1177/0272989X12458724}{doi:10.1177/0272989X12458724}]
+[\href{https://doi.org/10.1177/0272989X12458724}{doi:10.1177/0272989X12458724}]
 
 J.B. Carlin (1992),
 \emph{Meta-analysis for 2 × 2 tables: a Bayesian approach},
 Statistics in Medicine 11(2):141-158.
-[\href{http://dx.doi.org/10.1002/sim.4780110202}{doi:10.1002/sim.4780110202}]
+[\href{https://doi.org/10.1002/sim.4780110202}{doi:10.1002/sim.4780110202}]
 }

--- a/gemtc/man/certolizumab.Rd
+++ b/gemtc/man/certolizumab.Rd
@@ -8,7 +8,7 @@
 S. Dias, A.J. Sutton, N.J. Welton, and A.E. Ades (2013b),
 \emph{Heterogeneity - Subgroups, Meta-Regression, Bias, and Bias-Adjustment},
 Medical Decision Making 33(5):618-640. \cr
-[\href{http://dx.doi.org/10.1177/0272989X13485157}{doi:10.1177/0272989X13485157}]
+[\href{https://doi.org/10.1177/0272989X13485157}{doi:10.1177/0272989X13485157}]
 }
 \examples{
 # Run RE regression model with informative heterogeneity prior

--- a/gemtc/man/depression.Rd
+++ b/gemtc/man/depression.Rd
@@ -8,5 +8,5 @@
 Cipriani et al. (2009),
 \emph{Comparative efficacy and acceptability of 12 new-generation antidepressants: a multiple-treatments meta-analysis},
 Lancet 373(9665):746-758.
-[\href{http://dx.doi.org/10.1016/S0140-6736(09)60046-5}{doi:10.1016/S0140-6736(09)60046-5}]
+[\href{https://doi.org/10.1016/S0140-6736(09)60046-5}{doi:10.1016/S0140-6736(09)60046-5}]
 }

--- a/gemtc/man/dietfat.Rd
+++ b/gemtc/man/dietfat.Rd
@@ -8,10 +8,10 @@
 S. Dias, A.J. Sutton, A.E. Ades, and N.J. Welton (2013a),
 \emph{A Generalized Linear Modeling Framework for Pairwise and Network Meta-analysis of Randomized Controlled Trials},
 Medical Decision Making 33(5):607-617.
-[\href{http://dx.doi.org/10.1177/0272989X12458724}{doi:10.1177/0272989X12458724}]
+[\href{https://doi.org/10.1177/0272989X12458724}{doi:10.1177/0272989X12458724}]
 
 Hooper et al. (2000),
 \emph{Reduced or modified dietary fat for preventing cardiovascular disease},
 Cochrane Database of Systematic Reviews 2:CD002137.
-[\href{http://dx.doi.org/10.1002/14651858.CD002137}{doi:10.1002/14651858.CD002137}]
+[\href{https://doi.org/10.1002/14651858.CD002137}{doi:10.1002/14651858.CD002137}]
 }

--- a/gemtc/man/gemtc-package.Rd
+++ b/gemtc/man/gemtc-package.Rd
@@ -25,42 +25,42 @@ The source for GeMTC is available under the GPL-3 on \href{https://github.com/ge
 S. Dias, N.J. Welton, D.M. Caldwell, and A.E. Ades (2010),
 \emph{Checking consistency in mixed treatment comparison meta-analysis},
 Statistics in Medicine 29(7-8, Sp. Iss. SI):932-944.\cr
-[\href{http://dx.doi.org/10.1002/sim.3767}{doi:10.1002/sim.3767}]
+[\href{https://doi.org/10.1002/sim.3767}{doi:10.1002/sim.3767}]
 
 S. Dias, A.J. Sutton, A.E. Ades, and N.J. Welton (2013a),
 \emph{A Generalized Linear Modeling Framework for Pairwise and Network Meta-analysis of Randomized Controlled Trials},
 Medical Decision Making 33(5):607-617.
-[\href{http://dx.doi.org/10.1177/0272989X12458724}{doi:10.1177/0272989X12458724}]
+[\href{https://doi.org/10.1177/0272989X12458724}{doi:10.1177/0272989X12458724}]
 
 S. Dias, A.J. Sutton, N.J. Welton, and A.E. Ades (2013b),
 \emph{Heterogeneity - Subgroups, Meta-Regression, Bias, and Bias-Adjustment},
 Medical Decision Making 33(5):618-640. \cr
-[\href{http://dx.doi.org/10.1177/0272989X13485157}{doi:10.1177/0272989X13485157}]
+[\href{https://doi.org/10.1177/0272989X13485157}{doi:10.1177/0272989X13485157}]
 
 S. Dias, N.J. Welton, A.J. Sutton, D.M. Caldwell, G. Lu, and A.E. Ades (2013c),
 \emph{Inconsistency in Networks of Evidence Based on Randomized Controlled Trials},
 Medical Decision Making 33(5):641-656.
-[\href{http://dx.doi.org/10.1177/0272989X12455847}{doi:10.1177/0272989X12455847}]
+[\href{https://doi.org/10.1177/0272989X12455847}{doi:10.1177/0272989X12455847}]
 
 A. Gelman, A. Jakulin, M. Grazia Pittau, Y.-S. Su (2008),
 \emph{A weakly informative default prior distribution for logistic and other regression models},
 The Annals of Applied Statistics 2(4):1360-1383.
-[\href{http://dx.doi.org/10.1214/08-AOAS191}{doi:10.1214/08-AOAS191}]
+[\href{https://doi.org/10.1214/08-AOAS191}{doi:10.1214/08-AOAS191}]
 
 R.M. Turner, J. Davey, M.J. Clarke, S.G. Thompson, J.P.T. Higgins (2012),
 \emph{Predicting the extent of heterogeneity in meta-analysis, using empirical data from the Cochrane Database of Systematic Reviews},
 International Journal of Epidemiology 41(3):818-827.
-[\href{http://dx.doi.org/10.1093/ije/dys041}{doi:10.1093/ije/dys041}]
+[\href{https://doi.org/10.1093/ije/dys041}{doi:10.1093/ije/dys041}]
 
 G. van Valkenhoef, G. Lu, B. de Brock, H. Hillege, A.E. Ades, and N.J. Welton (2012),
 \emph{Automating network meta-analysis},
 Research Synthesis Methods 3(4):285-299.
-[\href{http://dx.doi.org/10.1002/jrsm.1054}{doi:10.1002/jrsm.1054}]
+[\href{https://doi.org/10.1002/jrsm.1054}{doi:10.1002/jrsm.1054}]
 
 G. van Valkenhoef, S. Dias, A.E. Ades, and N.J. Welton (2015),
 \emph{Automated generation of node-splitting models for assessment of inconsistency in network meta-analysis},
 Research Synthesis Methods, accepted manuscript.
-[\href{http://dx.doi.org/10.1002/jrsm.1167}{doi:10.1002/jrsm.1167}]
+[\href{https://doi.org/10.1002/jrsm.1167}{doi:10.1002/jrsm.1167}]
 
 G. van Valkenhoef et al. (draft),
 \emph{Modeling inconsistency as heterogeneity in network meta-analysis},
@@ -69,7 +69,7 @@ draft manuscript.
 D.E. Warn, S.G. Thompson, and D.J. Spiegelhalter (2002),
 \emph{Bayesian random effects meta-analysis of trials with binary outcomes: methods for the absolute risk difference and relative risk scales},
 Statistics in Medicine 21(11):1601-1623.
-[\href{http://dx.doi.org/10.1002/sim.1189}{doi:10.1002/sim.1189}]
+[\href{https://doi.org/10.1002/sim.1189}{doi:10.1002/sim.1189}]
 
 }
 \seealso{

--- a/gemtc/man/hfPrevention.Rd
+++ b/gemtc/man/hfPrevention.Rd
@@ -8,7 +8,7 @@
 S. Dias, A.J. Sutton, N.J. Welton, and A.E. Ades (2013b),
 \emph{Heterogeneity - Subgroups, Meta-Regression, Bias, and Bias-Adjustment},
 Medical Decision Making 33(5):618-640. \cr
-[\href{http://dx.doi.org/10.1177/0272989X13485157}{doi:10.1177/0272989X13485157}]
+[\href{https://doi.org/10.1177/0272989X13485157}{doi:10.1177/0272989X13485157}]
 }
 \examples{
 # Build a model similar to Program 1(a) from Dias et al. (2013b):

--- a/gemtc/man/parkinson.Rd
+++ b/gemtc/man/parkinson.Rd
@@ -14,5 +14,5 @@
 Franchini et al. (2012),
 \emph{Accounting for correlation in network meta-analysis with multi-arm trials},
 Research Synthesis Methods, 3(2):142-160.
-[\href{http://dx.doi.org/10.1002/jrsm.1049}{doi:10.1002/jrsm.1049}]
+[\href{https://doi.org/10.1002/jrsm.1049}{doi:10.1002/jrsm.1049}]
 }

--- a/gemtc/man/smoking.Rd
+++ b/gemtc/man/smoking.Rd
@@ -8,10 +8,10 @@
 Lu and Ades (2006),
 \emph{Assessing Evidence Inconsistency in Mixed Treatment Comparisons},
 Journal of the American Statistical Society, 101(474):447-459.
-[\href{http://dx.doi.org/10.1198/016214505000001302}{doi:10.1198/016214505000001302}]
+[\href{https://doi.org/10.1198/016214505000001302}{doi:10.1198/016214505000001302}]
 
 Hasselblad (1998),
 \emph{Meta-analysis of multitreatment studies},
 Medical Decision Making 18(1):37-43.
-[\href{http://dx.doi.org/10.1177/0272989X9801800110}{doi:10.1177/0272989X9801800110}]
+[\href{https://doi.org/10.1177/0272989X9801800110}{doi:10.1177/0272989X9801800110}]
 }

--- a/gemtc/man/thrombolytic.Rd
+++ b/gemtc/man/thrombolytic.Rd
@@ -8,10 +8,10 @@
 Lu and Ades (2006),
 \emph{Assessing Evidence Inconsistency in Mixed Treatment Comparisons},
 Journal of the American Statistical Society, 101(474):447-459.
-[\href{http://dx.doi.org/10.1198/016214505000001302}{10.1198/016214505000001302}]
+[\href{https://doi.org/10.1198/016214505000001302}{10.1198/016214505000001302}]
 
 Boland et al. (2003),
 \emph{Early thrombolysis for the treatment of acute myocardial infarction: a systematic review and economic evaluation},
 Health Technology Assessment 7(15):1-136.
-[\href{http://dx.doi.org/10.3310/hta7150}{doi:10.3310/hta7150}]
+[\href{https://doi.org/10.3310/hta7150}{doi:10.3310/hta7150}]
 }

--- a/gemtc/tests/testthat/test-validate-riskratio.R
+++ b/gemtc/tests/testthat/test-validate-riskratio.R
@@ -1,7 +1,7 @@
 context("[validate] Risk ratio example")
 
 # Example from http://www.statsdirect.com/help/default.htm#meta_analysis/relative_risk.htms
-# Original source http://dx.doi.org/10.1016/0895-4356(91)90261-7
+# Original source https://doi.org/10.1016/0895-4356(91)90261-7
 
 # Results of the Bayesian FE model closely match the frequentist RR of 0.913608 (0.8657, 0.964168)
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates all DOI links.

Cheers!