### PR TITLE
Vendor truncnorm::rtruncnorm and drop truncnorm dependency

### DIFF
--- a/gemtc/DESCRIPTION
+++ b/gemtc/DESCRIPTION
@@ -29,7 +29,6 @@ Imports:
     utils,
     grid,
     rjags (>= 4-0),
-    truncnorm,
     Rglpk,
     forcats (>= 0.5.0)
 Suggests:
@@ -78,4 +77,5 @@ Collate:
     'regression.R'
     'relative.effect.R'
     'relative.effect.table.R'
+    'truncnorm.R'
 RoxygenNote: 7.2.3

--- a/gemtc/R/inits.R
+++ b/gemtc/R/inits.R
@@ -212,7 +212,7 @@ mtc.init.hy <- function(hy.prior, om.scale, n.chain) {
     args[[3]] = sqrt(1/args[[3]])
   }
   values <- if (hy.prior[['distr']] == "dhnorm") { # special case dhnorm
-    truncnorm::rtruncnorm(args[[1]], a=0, mean = args[[2]], sd = args[[3]])
+    truncnorm__rtruncnorm(args[[1]], a=0, mean = args[[2]], sd = args[[3]])
   } else {
     values <- do.call(fn, args)
   }
@@ -298,7 +298,7 @@ mtc.init <- function(model) {
       param.limits <- c(findLimit(constr[['mat']], constr[['rhs']], constr[['eq']], params == param, FALSE),
                         findLimit(constr[['mat']], constr[['rhs']], constr[['eq']], params == param, TRUE))
 
-      x[param] <- truncnorm::rtruncnorm(n=1,
+      x[param] <- truncnorm__rtruncnorm(n=1,
                                         mean=param.mle[['mean']],
                                         sd=model[['var.scale']] * param.mle[['std.err']],
                                         a=param.limits[1], b=param.limits[2])

--- a/gemtc/R/truncnorm.R
+++ b/gemtc/R/truncnorm.R
@@ -1,0 +1,35 @@
+# The contents of this file have been adapted from version 1.0-9 of the {truncnorm} package, retrieved from:
+#   https://github.com/olafmersmann/truncnorm/tree/28593c0b454bdbe860bc00e8e23690c12af89927
+# The package is credited to
+#   Olaf Mersmann, Heike Trautmann, Detlef Steuer and Bjorn Bornkamp
+# and is released under the GNU General Public Licence v2 (or later).
+# The package does not include a copy of that license, so it is not reproduced here.
+# 
+# The superficial changes that led to this particular file were performed by Miguel Lechon on behalf of
+# Boehringer-Ingelheim Pharma GmbH & Co.KG. They do not deviate meaningfully from the original work, so no
+# separate copyright is claimed.
+#
+
+##
+## truncnorm.R - Interface to truncnorm.c
+##
+## Authors:
+##  Heike Trautmann  <trautmann@statistik.uni-dortmund.de>
+##  Detlef Steuer    <detlef.steuer@hsu-hamburg.de>
+##  Olaf Mersmann    <olafm@statistik.uni-dortmund.de>
+##
+
+truncnorm__rtruncnorm <- function(n, a=-Inf, b=Inf, mean=0, sd=1) {
+  stopifnot(length(a) > 0,
+            length(b) > 0,
+            length(mean) > 0,
+            length(sd) > 0)
+  if (length(n) > 1)
+    n <- length(n)
+  else if (!is.numeric(n))
+    stop("non-numeric argument n.")
+  else if (n == 0)
+    return(NULL)
+  .Call(C_do_rtruncnorm, as.integer(n),
+        as.numeric(a), as.numeric(b), as.numeric(mean), as.numeric(sd))
+}

--- a/gemtc/src/Makevars
+++ b/gemtc/src/Makevars
@@ -1,2 +1,2 @@
 PKG_CFLAGS=$(C_VISIBILITY)
-OBJECTS=init.o rank.o
+OBJECTS=init.o rank.o rtruncnorm.o

--- a/gemtc/src/gemtc.h
+++ b/gemtc/src/gemtc.h
@@ -2,3 +2,4 @@
 #include <Rinternals.h>
 
 SEXP gemtc_rank_count(SEXP _t);
+SEXP C_do_rtruncnorm(SEXP s_n, SEXP s_a, SEXP s_b, SEXP s_mean, SEXP s_sd);

--- a/gemtc/src/init.c
+++ b/gemtc/src/init.c
@@ -3,6 +3,7 @@
 
 static const R_CallMethodDef callMethods[] = {
   { "gemtc_rank_count", (DL_FUNC) &gemtc_rank_count, 1 },
+  { "C_do_rtruncnorm", (DL_FUNC) &C_do_rtruncnorm, 5 },
   { NULL, NULL, 0 }
 };
 

--- a/gemtc/src/rtruncnorm.c
+++ b/gemtc/src/rtruncnorm.c
@@ -1,0 +1,231 @@
+/* The contents of this file have been adapted from version 1.0-9 of the {truncnorm} package, retrieved from:
+ *   https://github.com/olafmersmann/truncnorm/tree/28593c0b454bdbe860bc00e8e23690c12af89927
+ * The package is credited to
+ *   Olaf Mersmann, Heike Trautmann, Detlef Steuer and Bjorn Bornkamp
+ * and is released under the GNU General Public Licence v2 (or later).
+ * The package does not include a copy of that license, so it is not reproduced here.
+ *
+ * The superficial changes that led to this particular file were performed by Miguel Lechon on behalf of
+ * Boehringer-Ingelheim Pharma GmbH & Co.KG. They do not deviate meaningfully from the original work, so no
+ * separate copyright is claimed.
+ */
+
+/*
+ * rtruncnorm.c - Random truncated normal number generator.
+ *
+ * Authors:
+ *  Björn Bornkamp   <bornkamp@statistik.tu-dortmund.de>
+ *  Olaf Mersmann    <olafm@statistik.uni-dortmund.de>
+ */
+
+#include <R.h>
+#include <Rinternals.h>
+#include <Rmath.h>
+
+#define RTN_CHECK_ARG_IS_REAL_VECTOR(A)					\
+    if (!isReal(A) || !isVector(A))					\
+	error("Argument '" #A "' is not a real vector.");
+
+#define RTN_CHECK_ARG_IS_INT_VECTOR(A)					\
+    if (!isInteger(A) || !isVector(A))					\
+	error("Argument '" #A "' is not an integer vector.");
+
+/*
+ * Unpack a real vector stored in SEXP S.
+ */
+#define RTN_UNPACK_REAL_VECTOR(S, D, N)             \
+    RTN_CHECK_ARG_IS_REAL_VECTOR(S);		\
+    double *D = REAL(S);			\
+    const R_len_t N = length(S);                   
+
+/*
+ * Unpack a single integer stored in SEXP S.
+ */
+#define RTN_UNPACK_INT(S, I)			\
+    RTN_CHECK_ARG_IS_INT_VECTOR(S);			\
+    int I = INTEGER(S)[0];			\
+
+#define RTN_ALLOC_REAL_VECTOR(S, D, N)                                             \
+  SEXP S;                                                                      \
+  PROTECT(S = allocVector(REALSXP, N));                                        \
+  double *D = REAL(S);
+
+#define RTN_MAX(A, B) ((A > B) ? (A) : (B))
+
+#ifdef DEBUG
+#define RTN_SAMPLER_DEBUG(N, A, B) Rprintf("%8s(%f, %f)\n", N, A, B)
+#else
+#define RTN_SAMPLER_DEBUG(N, A, B)
+#endif
+
+static const double RTN_t1 = 0.15;
+static const double RTN_t2 = 2.18;
+static const double RTN_t3 = 0.725;
+static const double RTN_t4 = 0.45;
+
+/* Exponential rejection sampling (a,inf) */
+static R_INLINE double RTN_ers_a_inf(double a) {
+  RTN_SAMPLER_DEBUG("RTN_ers_a_inf", a, R_PosInf);
+  const double ainv = 1.0 / a;
+  double x, rho;
+  do {
+    x = rexp(ainv) + a; /* rexp works with 1/lambda */
+    rho = exp(-0.5 * pow((x - a), 2));
+  } while (runif(0, 1) > rho);
+  return x;
+}
+
+/* Exponential rejection sampling (a,b) */
+static R_INLINE double RTN_ers_a_b(double a, double b) {
+  RTN_SAMPLER_DEBUG("RTN_ers_a_b", a, b);
+  const double ainv = 1.0 / a;
+  double x, rho;
+  do {
+    x = rexp(ainv) + a; /* rexp works with 1/lambda */
+    rho = exp(-0.5 * pow((x - a), 2));
+  } while (runif(0, 1) > rho || x > b);
+  return x;
+}
+
+/* Normal rejection sampling (a,b) */
+static R_INLINE double RTN_nrs_a_b(double a, double b) {
+  RTN_SAMPLER_DEBUG("RTN_nrs_a_b", a, b);
+  double x = -DBL_MAX;
+  while (x < a || x > b) {
+    x = rnorm(0, 1);
+  }
+  return x;
+}
+
+/* Normal rejection sampling (a,inf) */
+static R_INLINE double RTN_nrs_a_inf(double a) {
+  RTN_SAMPLER_DEBUG("RTN_nrs_a_inf", a, R_PosInf);
+  double x = -DBL_MAX;
+  while (x < a) {
+    x = rnorm(0, 1);
+  }
+  return x;
+}
+
+/* Half-normal rejection sampling */
+static double RTN_hnrs_a_b(double a, double b) {
+  RTN_SAMPLER_DEBUG("RTN_hnrs_a_b", a, b);
+  double x = a - 1.0;
+  while (x < a || x > b) {
+    x = rnorm(0, 1);
+    x = fabs(x);
+  }
+  return x;
+}
+
+/* Uniform rejection sampling */
+static R_INLINE double RTN_urs_a_b(double a, double b) {
+  RTN_SAMPLER_DEBUG("RTN_urs_a_b", a, b);
+  const double phi_a = dnorm(a, 0.0, 1.0, FALSE);
+  double x = 0.0;
+
+  /* Upper bound of normal density on [a, b] */
+  const double ub = a < 0 && b > 0 ? M_1_SQRT_2PI : phi_a;
+  do {
+    x = runif(a, b);
+  } while (runif(0, 1) * ub > dnorm(x, 0, 1, 0));
+  return x;
+}
+
+/* Previously this was refered to as type 1 sampling: */
+static inline double RTN_r_lefttruncnorm(double a, double mean, double sd) {
+  const double alpha = (a - mean) / sd;
+  if (alpha < RTN_t4) {
+    return mean + sd * RTN_nrs_a_inf(alpha);
+  } else {
+    return mean + sd * RTN_ers_a_inf(alpha);
+  }
+}
+
+static R_INLINE double RTN_r_righttruncnorm(double b, double mean, double sd) {
+  const double beta = (b - mean) / sd;
+  /* Exploit symmetry: */
+  return mean - sd * RTN_r_lefttruncnorm(-beta, 0.0, 1.0);
+}
+
+static R_INLINE double RTN_r_truncnorm(double a, double b, double mean, double sd) {
+  const double alpha = (a - mean) / sd;
+  const double beta = (b - mean) / sd;
+  const double phi_a = dnorm(alpha, 0.0, 1.0, FALSE);
+  const double phi_b = dnorm(beta, 0.0, 1.0, FALSE);
+  if (beta <= alpha) {
+    return NA_REAL;
+  } else if (alpha <= 0 && 0 <= beta) { /* 2 */
+    if (phi_a <= RTN_t1 || phi_b <= RTN_t1) {   /* 2 (a) */
+      return mean + sd * RTN_nrs_a_b(alpha, beta);
+    } else { /* 2 (b) */
+      return mean + sd * RTN_urs_a_b(alpha, beta);
+    }
+  } else if (alpha > 0) {      /* 3 */
+    if (phi_a / phi_b <= RTN_t2) { /* 3 (a) */
+      return mean + sd * RTN_urs_a_b(alpha, beta);
+    } else {
+      if (alpha < RTN_t3) { /* 3 (b) */
+        return mean + sd * RTN_hnrs_a_b(alpha, beta);
+      } else { /* 3 (c) */
+        return mean + sd * RTN_ers_a_b(alpha, beta);
+      }
+    }
+  } else {                     /* 3s */
+    if (phi_b / phi_a <= RTN_t2) { /* 3s (a) */
+      return mean - sd * RTN_urs_a_b(-beta, -alpha);
+    } else {
+      if (beta > -RTN_t3) { /* 3s (b) */
+        return mean - sd * RTN_hnrs_a_b(-beta, -alpha);
+      } else { /* 3s (c) */
+        return mean - sd * RTN_ers_a_b(-beta, -alpha);
+      }
+    }
+  }
+}
+
+SEXP C_do_rtruncnorm(SEXP s_n, SEXP s_a, SEXP s_b, SEXP s_mean, SEXP s_sd) {
+  R_len_t i, nn;
+  RTN_UNPACK_INT(s_n, n);
+  if (NA_INTEGER == n)
+    error("n is NA - aborting.");
+  RTN_UNPACK_REAL_VECTOR(s_a, a, n_a);
+  RTN_UNPACK_REAL_VECTOR(s_b, b, n_b);
+  RTN_UNPACK_REAL_VECTOR(s_mean, mean, n_mean);
+  RTN_UNPACK_REAL_VECTOR(s_sd, sd, n_sd);
+
+  nn = RTN_MAX(n, RTN_MAX(RTN_MAX(n_a, n_b), RTN_MAX(n_mean, n_sd)));
+  RTN_ALLOC_REAL_VECTOR(s_ret, ret, nn);
+
+  GetRNGstate();
+  for (i = 0; i < nn; ++i) {
+    const double ca = a[i % n_a];
+    const double cb = b[i % n_b];
+    const double cmean = mean[i % n_mean];
+    const double csd = sd[i % n_sd];
+
+    if (R_FINITE(ca) && R_FINITE(cb)) {
+      ret[i] = RTN_r_truncnorm(ca, cb, cmean, csd);
+    } else if (R_NegInf == ca && R_FINITE(cb)) {
+      ret[i] = RTN_r_righttruncnorm(cb, cmean, csd);
+    } else if (R_FINITE(ca) && R_PosInf == cb) {
+      ret[i] = RTN_r_lefttruncnorm(ca, cmean, csd);
+    } else if (R_NegInf == ca && R_PosInf == cb) {
+      ret[i] = rnorm(cmean, csd);
+    } else {
+      ret[i] = NA_REAL;
+    }
+    R_CheckUserInterrupt();
+  }
+  PutRNGstate();
+  UNPROTECT(1); /* s_ret */
+  return s_ret;
+}
+
+#undef RTN_CHECK_ARG_IS_REAL_VECTOR
+#undef RTN_CHECK_ARG_IS_INT_VECTOR
+#undef RTN_UNPACK_REAL_VECTOR
+#undef RTN_UNPACK_INT
+#undef RTN_ALLOC_REAL_VECTOR
+#undef RTN_MAX
+#undef RTN_SAMPLER_DEBUG

--- a/gemtc/tests/testthat/test-rtruncnorm.R
+++ b/gemtc/tests/testthat/test-rtruncnorm.R
@@ -1,0 +1,107 @@
+# The contents of this file have been adapted from version 1.0-9 of the {truncnorm} package, retrieved from:
+#   https://github.com/olafmersmann/truncnorm/tree/28593c0b454bdbe860bc00e8e23690c12af89927
+# The package is credited to
+#   Olaf Mersmann, Heike Trautmann, Detlef Steuer and Bjorn Bornkamp
+# and is released under the GNU General Public Licence v2 (or later).
+# The package does not include a copy of that license, so it is not reproduced here.
+# 
+# The superficial changes that led to this particular file were performed by Miguel Lechon on behalf of
+# Boehringer-Ingelheim Pharma GmbH & Co.KG. They do not deviate meaningfully from the original work, so no
+# separate copyright is claimed.
+#
+
+##
+## Don't segfault!
+##
+
+context("rtruncnorm reg-segfault")
+
+expect_error(truncnorm__rtruncnorm(1, numeric(0), 1, 0, 1))
+expect_error(truncnorm__rtruncnorm(1, 0, numeric(0), 0, 1))
+expect_error(truncnorm__rtruncnorm(1, 0, 1, numeric(0), 1))
+expect_error(truncnorm__rtruncnorm(1, 0, 1, 0, numeric(0)))
+
+
+################################################################################
+## Sanity checks on random number generators
+
+context("rtruncnorm sanity checks")
+
+check_r <- function(a, b, mean, sd, n=10000) {
+  prefix <- sprintf("R: a=%f, b=%f, mean=%f, sd=%f", a, b, mean, sd)
+  x <- truncnorm__rtruncnorm(n, a, b, mean, sd)
+  e.x <- mean(x)
+
+  ## FIXME: Really sample from open intervall?
+  test_that(prefix, {
+    expect_true(all(x > a))
+    expect_true(all(x < b))
+  })
+}
+
+## rtruncnorm == rnorm:
+check_r(-Inf, Inf, 0, 1)
+
+## 0 in (a, b):
+check_r(-1, 1, 0, 1)
+check_r(-1, 1, 1, 1)
+check_r(-1, 1, 0, 2)
+
+## 0 < (a, b):
+check_r(1, 2, 0, 1)
+check_r(1, 2, 1, 1)
+check_r(1, 2, 0, 2)
+
+## 0 > (a, b):
+check_r(-2, -1, 0, 1)
+check_r(-2, -1, 1, 1)
+check_r(-2, -1, 0, 2)
+
+## left truncation:
+check_r(-2, Inf, 0, 1)
+check_r(-2, Inf, 1, 1)
+check_r(-2, Inf, 0, 2)
+check_r( 0, Inf, 0, 1)
+check_r( 0, Inf, 1, 1)
+check_r( 0, Inf, 0, 2)
+check_r( 2, Inf, 0, 1)
+check_r( 2, Inf, 1, 1)
+check_r( 2, Inf, 0, 2)
+
+check_r(-0.2, Inf, 0, 1)
+check_r(-0.2, Inf, 1, 1)
+check_r(-0.2, Inf, 0, 2)
+check_r( 0.0, Inf, 0, 1)
+check_r( 0.0, Inf, 1, 1)
+check_r( 0.0, Inf, 0, 2)
+check_r( 0.2, Inf, 0, 1)
+check_r( 0.2, Inf, 1, 1)
+check_r( 0.2, Inf, 0, 2)
+
+## Right truncation:
+check_r(-Inf, -2, 0, 1)
+check_r(-Inf, -2, 1, 1)
+check_r(-Inf, -2, 0, 2)
+check_r(-Inf,  0, 0, 1)
+check_r(-Inf,  0, 1, 1)
+check_r(-Inf,  0, 0, 2)
+check_r(-Inf,  2, 0, 1)
+check_r(-Inf,  2, 1, 1)
+check_r(-Inf,  2, 0, 2)
+
+check_r(-Inf, -0.2, 0, 1)
+check_r(-Inf, -0.2, 1, 1)
+check_r(-Inf, -0.2, 0, 2)
+check_r(-Inf,  0.0, 0, 1)
+check_r(-Inf,  0.0, 1, 1)
+check_r(-Inf,  0.0, 0, 2)
+check_r(-Inf,  0.2, 0, 1)
+check_r(-Inf,  0.2, 1, 1)
+check_r(-Inf,  0.2, 0, 2)
+
+## Extreme examples:
+check_r(-5, -4, 0, 1)
+
+## Integer examples:
+check_r(-5L, -4L, 0L, 1L)
+


### PR DESCRIPTION
Dear @gertvv,

I have been tasked with issuing a PR that, if accepted, would satisfy the request on issue #85 of this repository.

I have tried my best to isolate and reshape the `truncnorm::rtruncnorm` function and its dependencies so that they slot into your package while disturbing it minimally. I've performed the necessary changes to a fork of the `rtruncnorm` package over the course of [a few commits](https://github.com/ml-ebs-ext/truncnorm/commits/master/?since=2026-06-08&until=2026-06-09). Each of them constitutes a self-contained, trivial transformation of the original codebase that does not alter the behavior of the `rtruncnorm` function.

I am deeply appreciative of your time and will gladly assist you in anything related to this matter, if you find it worth pursuing.

miguel